### PR TITLE
FEATURE: Allow usage of complex ANT-style glob patterns in .editorconfig files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,19 +3,9 @@ end_of_line = lf
 insert_final_newline = true
 charset = utf-8
 trim_trailing_whitespace = true
-
-[*.php]
-indent_style = space
-indent_size = 4
-
-[*.yml]
 indent_style = space
 indent_size = 2
 
-[*.json]
-indent_style = space
-indent_size = 4
-
-[*.md]
+[*.{json,md,php}]
 indent_style = space
 indent_size = 4

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Logo](https://raw.githubusercontent.com/editorconfig-checker/editorconfig-checker.php/master/Docs/logo.png "Logo")
 
-This is a __dependency-free__ tool to check if given files implement your .editorconfig rules.
+This is a command-line tool to check if given files implement your .editorconfig rules.
 
 [![Build Status](https://travis-ci.org/editorconfig-checker/editorconfig-checker.php.svg?branch=master)](https://travis-ci.org/editorconfig-checker/editorconfig-checker.php)
 [![Latest Stable Version](https://poser.pugx.org/editorconfig-checker/editorconfig-checker/v/stable)](https://packagist.org/packages/editorconfig-checker/editorconfig-checker)

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,9 @@
             "php": "7"
         }
     },
-    "require": {},
+    "require": {
+        "webmozart/glob": "^4.1"
+    },
     "require-dev": {
         "squizlabs/php_codesniffer": "^2.7.1",
         "phpunit/phpunit": "^6.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,9 +4,153 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "2174e16331e082488fd91e36ff113278",
-    "content-hash": "4c7571de5e984f6055093f1d6dc9a6ba",
-    "packages": [],
+    "hash": "f3d7cecfdb15dc538cf11834eea94031",
+    "content-hash": "c8e44722524642de4b11b8819d51be75",
+    "packages": [
+        {
+            "name": "webmozart/assert",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/assert.git",
+                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/2db61e59ff05fe5126d152bd0655c9ea113e550f",
+                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6",
+                "sebastian/version": "^1.0.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "time": "2016-11-23 20:04:58"
+        },
+        {
+            "name": "webmozart/glob",
+            "version": "4.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/glob.git",
+                "reference": "3cbf63d4973cf9d780b93d2da8eec7e4a9e63bbe"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/glob/zipball/3cbf63d4973cf9d780b93d2da8eec7e4a9e63bbe",
+                "reference": "3cbf63d4973cf9d780b93d2da8eec7e4a9e63bbe",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3|^7.0",
+                "webmozart/path-util": "^2.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6",
+                "sebastian/version": "^1.0.1",
+                "symfony/filesystem": "^2.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Glob\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "A PHP implementation of Ant's glob.",
+            "time": "2015-12-29 11:14:33"
+        },
+        {
+            "name": "webmozart/path-util",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/path-util.git",
+                "reference": "d939f7edc24c9a1bb9c0dee5cb05d8e859490725"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/path-util/zipball/d939f7edc24c9a1bb9c0dee5cb05d8e859490725",
+                "reference": "d939f7edc24c9a1bb9c0dee5cb05d8e859490725",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "webmozart/assert": "~1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6",
+                "sebastian/version": "^1.0.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\PathUtil\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "A robust cross-platform utility for normalizing, comparing and modifying file paths.",
+            "time": "2015-12-17 08:42:14"
+        }
+    ],
     "packages-dev": [
         {
             "name": "doctrine/instantiator",
@@ -1293,56 +1437,6 @@
                 "standards"
             ],
             "time": "2016-11-30 04:02:31"
-        },
-        {
-            "name": "webmozart/assert",
-            "version": "1.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webmozart/assert.git",
-                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/2db61e59ff05fe5126d152bd0655c9ea113e550f",
-                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3.3 || ^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.6",
-                "sebastian/version": "^1.0.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.3-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Webmozart\\Assert\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@gmail.com"
-                }
-            ],
-            "description": "Assertions to validate method input/output with nice error messages.",
-            "keywords": [
-                "assert",
-                "check",
-                "validate"
-            ],
-            "time": "2016-11-23 20:04:58"
         }
     ],
     "aliases": [],

--- a/src/EditorconfigChecker.php
+++ b/src/EditorconfigChecker.php
@@ -1,14 +1,19 @@
 <?php
-
 namespace EditorconfigChecker;
 
 use EditorconfigChecker\Cli\Cli;
 use EditorconfigChecker\Cli\Logger;
 
-spl_autoload_register(function ($class) {
-    $newClass = str_replace('\\', '/', $class);
-    require_once($newClass . '.php');
-});
+$paths = [
+    __DIR__.'/../vendor/autoload.php',
+    __DIR__.'/../../../autoload.php'
+];
+foreach ($paths as $path) {
+    if (file_exists($path)) {
+        require_once $path;
+        break;
+    }
+}
 
 array_shift($argv);
 

--- a/src/EditorconfigChecker/Editorconfig/Editorconfig.php
+++ b/src/EditorconfigChecker/Editorconfig/Editorconfig.php
@@ -26,7 +26,7 @@ class Editorconfig
      */
     public function getRulesForFile($editorconfig, $fileName)
     {
-        return array_reduce(array_keys($editorconfig), function($carry, $pattern) use ($editorconfig, $fileName) {
+        return array_reduce(array_keys($editorconfig), function ($carry, $pattern) use ($editorconfig, $fileName) {
             $rules = $editorconfig[$pattern];
 
             return Glob::match(sprintf('%s/%s', getcwd(), $fileName), Path::makeAbsolute($pattern, getcwd())) ?

--- a/tests/Editorconfig/EditorconfigTest.php
+++ b/tests/Editorconfig/EditorconfigTest.php
@@ -30,6 +30,6 @@ final class EditorconfigTest extends TestCase
 
         $editorconfig = new Editorconfig();
         $rules = $editorconfig->getRulesForFile($allRules, 'Readme.md');
-        $this->assertEquals($rules, $expectedRules);
+        $this->assertEquals($expectedRules, $rules);
     }
 }


### PR DESCRIPTION
Given a configuration like:

```ini
[*]
end_of_line = lf
insert_final_newline = true
charset = utf-8
indent_style = tab

[*.{js,json}]
indent_style = space
indent_size = 4

[*.{yml,yaml,package.json}]
indent_style = space
indent_size = 2
```

The current implementation would apply the rule

```
indent_style = space
indent_size = 2
```

to `composer.json`.

The reason for this is a faulty interpretation of the matching rules in the configuration keys.

With this PR, the glob patterns for matching files with `.editorconfig` are interpreted correctly.