### PR TITLE
Enhance error output

### DIFF
--- a/src/EditorconfigChecker/Cli/Logger.php
+++ b/src/EditorconfigChecker/Cli/Logger.php
@@ -58,6 +58,12 @@ class Logger
      */
     public function printErrors()
     {
+        // only 1 error and no filename given = Fatal Error! (Eg. ".editorconfig not found!")
+        if ($this->errors[0]['fileName'] === null && $this->countErrors() === 1) {
+            printf('Fatal Error: %s' . PHP_EOL, $this->errors[0]['message']);
+            return;
+        }
+
         foreach ($this->errors as $errorNumber => $error) {
             printf('Error #%d' . PHP_EOL, $errorNumber);
             printf('  %s' . PHP_EOL, $error['message']);

--- a/src/EditorconfigChecker/Cli/Logger.php
+++ b/src/EditorconfigChecker/Cli/Logger.php
@@ -64,8 +64,8 @@ class Logger
             if (isset($error['lineNumber'])) {
                 printf("\t on line %d" . PHP_EOL, $error['lineNumber']);
             }
-            if (isset($error['file'])) {
-                printf("\t in file %s" . PHP_EOL, $error['file']);
+            if (isset($error['fileName'])) {
+                printf("\t in file %s" . PHP_EOL, $error['fileName']);
             }
             printf(PHP_EOL);
         }

--- a/src/EditorconfigChecker/Cli/Logger.php
+++ b/src/EditorconfigChecker/Cli/Logger.php
@@ -76,7 +76,7 @@ class Logger
             printf(PHP_EOL);
         }
 
-        printf('%d errors occurred' . PHP_EOL, $this->countErrors());
+        printf('%d files checked, %d errors occurred' . PHP_EOL, $this->getFiles(), $this->countErrors());
         printf('Check log above and fix the issues.' . PHP_EOL);
     }
 
@@ -113,14 +113,24 @@ class Logger
     }
 
     /**
-     * Set number of files for success message
+     * Set number of checked files
      *
      * @param int $files
      * @return void
      */
-    public function setFiles($files)
+    public function setFiles(int $files)
     {
         $this->files = $files;
+    }
+
+    /**
+     * Get the numer of checked files
+     *
+     * @return int
+     */
+    public function getFiles()
+    {
+        return $this->files;
     }
 
     /**

--- a/src/EditorconfigChecker/Cli/Logger.php
+++ b/src/EditorconfigChecker/Cli/Logger.php
@@ -50,7 +50,7 @@ class Logger
      */
     public function addError($message, $fileName = null, $lineNumber = null)
     {
-        array_push($this->errors, ['lineNumber' => $lineNumber, 'fileName' => $fileName, 'message' => $message]);
+        $this->errors[] = ['lineNumber' => $lineNumber, 'fileName' => $fileName, 'message' => $message];
     }
 
     /**

--- a/src/EditorconfigChecker/Cli/Logger.php
+++ b/src/EditorconfigChecker/Cli/Logger.php
@@ -64,18 +64,28 @@ class Logger
             return;
         }
 
-        foreach ($this->errors as $errorNumber => $error) {
-            printf('Error #%d' . PHP_EOL, $errorNumber);
-            printf('  %s' . PHP_EOL, $error['message']);
-            if (isset($error['lineNumber'])) {
-                printf('  on line %d' . PHP_EOL, $error['lineNumber']);
+        // sort error log by filename
+        array_multisort(array_map(function ($element) {
+            return $element['fileName'];
+        }, $this->errors), SORT_ASC, $this->errors);
+
+        $lastFile = '';
+        $errorSegment = 0;
+        foreach ($this->errors as $error) {
+            if ($lastFile !== $error['fileName']) {
+                $errorSegment++;
+                $lastFile = $error['fileName'];
+                printf('%04d) %s' . PHP_EOL, $errorSegment, $error['fileName']);
             }
-            if (isset($error['fileName'])) {
-                printf('  in file %s' . PHP_EOL, $error['fileName']);
+
+            printf('      %s', $error['message']);
+            if (false === empty($error['lineNumber'])) {
+                printf(' on line %d', $error['lineNumber']);
             }
             printf(PHP_EOL);
         }
 
+        printf(PHP_EOL);
         printf('%d files checked, %d errors occurred' . PHP_EOL, $this->getFiles(), $this->countErrors());
         printf('Check log above and fix the issues.' . PHP_EOL);
     }

--- a/src/EditorconfigChecker/Cli/Logger.php
+++ b/src/EditorconfigChecker/Cli/Logger.php
@@ -50,7 +50,7 @@ class Logger
      */
     public function addError($message, $fileName = null, $lineNumber = null)
     {
-        array_push($this->errors, ["lineNumber" => $lineNumber, "fileName" => $fileName, "message" => $message]);
+        array_push($this->errors, ['lineNumber' => $lineNumber, 'fileName' => $fileName, 'message' => $message]);
     }
 
     /**
@@ -59,13 +59,13 @@ class Logger
     public function printErrors()
     {
         foreach ($this->errors as $errorNumber => $error) {
-            printf("Error #%d" . PHP_EOL, $errorNumber);
-            printf("\t %s" . PHP_EOL, $error['message']);
+            printf('Error #%d' . PHP_EOL, $errorNumber);
+            printf('  %s' . PHP_EOL, $error['message']);
             if (isset($error['lineNumber'])) {
-                printf("\t on line %d" . PHP_EOL, $error['lineNumber']);
+                printf('  on line %d' . PHP_EOL, $error['lineNumber']);
             }
             if (isset($error['fileName'])) {
-                printf("\t in file %s" . PHP_EOL, $error['fileName']);
+                printf('  in file %s' . PHP_EOL, $error['fileName']);
             }
             printf(PHP_EOL);
         }


### PR DESCRIPTION
Enhance readability of the error log by sorting the error by filename
and encapsulating the errors into segments.

Old: 
````
…
Error #7736
  Not the right relation of spaces between lines
  on line 117
  in file foo.php
Error #7737
  Not the right relation of spaces between lines
  on line 210
  in file bar.php
Error #7738
  Not the right relation of spaces between lines
  on line 281
  in file foo.php

7738 errors occurred
Check log above and fix the issues.
````
New:
````
…
0875) bar.php
      Not the right relation of spaces between lines on line 210
0876) foo.php
      Not the right relation of spaces between lines on line 117
      Not the right relation of spaces between lines on line 281

2071 files checked, 7738 errors occurred
Check log above and fix the issues.
````

PS: This Feature-PR is based on Bugfix-PR #35 (if you want to handle these separately for semantic versioning).