### PR TITLE
[WIP][FEATURE] Tests: Test recursive rulesets

### DIFF
--- a/Build/TestFiles/Editorconfig/.editorconfig
+++ b/Build/TestFiles/Editorconfig/.editorconfig
@@ -3,6 +3,7 @@ root = true;
 [*]
 indent_style = space
 indent_size = 2
+insert_final_newline = true
 
 [*.php]
 indent_size = 4

--- a/Build/TestFiles/Editorconfig/RootFlagRules/.editorconfig
+++ b/Build/TestFiles/Editorconfig/RootFlagRules/.editorconfig
@@ -1,3 +1,5 @@
+root = true;
+
 [*]
 insert_final_newline = false
 trim_trailing_whitespace = true

--- a/Build/TestFiles/Editorconfig/onlyJsonRules/.editorconfig
+++ b/Build/TestFiles/Editorconfig/onlyJsonRules/.editorconfig
@@ -1,3 +1,3 @@
 [*json]
 indent_style = space
-indent_size = 2
+indent_size = 6

--- a/tests/Editorconfig/EditorconfigTest.php
+++ b/tests/Editorconfig/EditorconfigTest.php
@@ -5,46 +5,88 @@ use EditorconfigChecker\Editorconfig\Editorconfig;
 
 final class EditorconfigTest extends TestCase
 {
-    public function testGetRulesForFile()
+    protected $expectedRules;
+
+    protected function setUp()
     {
-        $expectedRules = [
+        $this->expectedRules = [
             'indent_style' => 'space',
-            'indent_size' => 4,
+            'indent_size' => 2,
+            'insert_final_newline' => true,
             'root' => 1
         ];
+    }
 
+    public function testGetRulesForFile()
+    {
         $editorconfig = new Editorconfig();
 
+        // expect rules for wildcard file pattern
         $rootDir = getcwd();
-        $rules = $editorconfig->getRulesForFile('./Build/TestFiles/Editorconfig/myFile.php', $rootDir);
-        $this->assertEquals($expectedRules, $rules);
+        $rules = $editorconfig->getRulesForFile('./Build/TestFiles/Editorconfig/myFile.txt', $rootDir);
+        $this->assertEquals($this->expectedRules, $rules);
 
+        // expect same rules if starting point differs
+        $rootDir = getcwd() . '/Build/TestFiles/Editorconfig';
+        $rules = $editorconfig->getRulesForFile('./myFile.txt', $rootDir);
+        $this->assertEquals($this->expectedRules, $rules);
+
+        // expect same rules if filename starts with non leading »./«
+        $rootDir = getcwd() . '/Build/TestFiles/Editorconfig';
+        $rules = $editorconfig->getRulesForFile('myFile.txt', $rootDir);
+        $this->assertEquals($this->expectedRules, $rules);
+
+        // expect merged rules for PHP file (wildcard & PHP match)
+        $this->expectedRules['indent_size'] = 4;
         $rootDir = getcwd() . '/Build/TestFiles/Editorconfig';
         $rules = $editorconfig->getRulesForFile('./Build/TestFiles/Editorconfig/myFile.php', $rootDir);
-        $this->assertEquals($expectedRules, $rules);
+        $this->assertEquals($this->expectedRules, $rules);
+    }
 
+    public function testGetRecursiveRulesForFile()
+    {
+        $editorconfig = new Editorconfig();
+
+        // expect same rules for PHP file in subfolder with JSON only editorconf
+        // (editorconfig rules not applied recursively)
+        $this->expectedRules['indent_size'] = 4;
         $rootDir = getcwd() . '/Build/TestFiles/Editorconfig';
-        $rules = $editorconfig->getRulesForFile('./Build/TestFiles/Editorconfig/onlyJsonRules/myFile.php', $rootDir);
-        $this->assertEquals($expectedRules, $rules);
+        $rules = $editorconfig->getRulesForFile('./onlyJsonRules/myFile.php', $rootDir);
+        $this->assertEquals($this->expectedRules, $rules);
 
-        $expectedRules['indent_size'] = 2;
+        // expect merged rules for JSON file in subfolder with JSON only
+        // editorconf (editorconfig rules applied recursively)
+        $this->expectedRules['indent_size'] = 6;
         $rootDir = getcwd() . '/Build/TestFiles/Editorconfig';
-        $rules = $editorconfig->getRulesForFile('./Build/TestFiles/Editorconfig/onlyJsonRules/myFile.json', $rootDir);
-        $this->assertEquals($expectedRules, $rules);
+        $rules = $editorconfig->getRulesForFile('./onlyJsonRules/myFile.json', $rootDir);
+        $this->assertEquals($this->expectedRules, $rules);
 
-
-        $expectedRules = [
-            'indent_style' => 'tab',
-            'trim_trailing_whitespace' => 1,
-            'insert_final_newline' => 1
-        ];
+        // expect merged rules for PHP file in subfolder with mixed editorconf
+        // (editorconfig rules applied recursively)
+        $this->expectedRules['indent_style'] = 'tab';
+        $this->expectedRules['indent_size'] = 4;
+        $this->expectedRules['trim_trailing_whitespace'] = true;
+        $this->expectedRules['insert_final_newline'] = false;
 
         $rootDir = getcwd() . '/Build/TestFiles/Editorconfig';
         $rules = $editorconfig->getRulesForFile('./ComposedRules/myFile.php', $rootDir);
-        $this->assertEquals($expectedRules, $rules);
+        $this->assertEquals($this->expectedRules, $rules);
 
-        /* test if files with non leading ./ return the same result */
-        $rules = $editorconfig->getRulesForFile('ComposedRules/myFile.php', $rootDir);
-        $this->assertEquals($expectedRules, $rules);
+        // expect rules not getting merged recursively if the subfolder is the
+        // starting point
+        $this->expectedRules = [
+            'indent_style' => 'tab',
+            'insert_final_newline' => false,
+            'trim_trailing_whitespace' => true
+        ];
+        $rootDir = getcwd() . '/Build/TestFiles/Editorconfig/ComposedRules';
+        $rules = $editorconfig->getRulesForFile('./myFile.php', $rootDir);
+        $this->assertEquals($this->expectedRules, $rules);
+
+        // expect rules not getting merged recursively if the subfolder contains
+        // a »root« flag in the editorconfig
+        $rootDir = getcwd() . '/Build/TestFiles/Editorconfig';
+        $rules = $editorconfig->getRulesForFile('./RootFlagRules/myFile.php', $rootDir);
+        $this->assertEquals($this->expectedRules, $rules);
     }
 }


### PR DESCRIPTION
Test the correct merge process of rules in single .editorconfig
files and whenever they are nested in subfolders.

If an .editorconfig is located in a top folder and another one
in a subfolder, then both should be merged, according to
https://github.com/editorconfig/editorconfig/issues/311#issuecomment-304712484