### PR TITLE
BUGFIX: Initialize variable with array instead of null

### DIFF
--- a/src/EditorconfigChecker/Editorconfig/Editorconfig.php
+++ b/src/EditorconfigChecker/Editorconfig/Editorconfig.php
@@ -51,7 +51,7 @@ class Editorconfig
         string $rootDir
     ) : array {
         $currentPath = $filePath;
-        $editorconfig = null;
+        $editorconfig = array();
 
         do {
             if (is_file($currentPath . '/.editorconfig')) {


### PR DESCRIPTION
because it needs to implement countable in order to call
sizeof() since PHP 7.2

closes #74