### PR TITLE
BUGFIX: Patterns never match any file under Windows

### DIFF
--- a/src/EditorconfigChecker/Editorconfig/Editorconfig.php
+++ b/src/EditorconfigChecker/Editorconfig/Editorconfig.php
@@ -31,8 +31,10 @@ class Editorconfig
             $rules = $editorconfig[$pattern];
 
             return $pattern === 'root' ? ['root' => $editorconfig[$pattern]] : (
-                Glob::match(sprintf('%s/%s', getcwd(), $fileName), Path::makeAbsolute('**/' . $pattern, getcwd())) ?
-                    array_merge($carry, $rules) : $carry
+                Glob::match(
+                    Path::normalize(sprintf('%s/%s', getcwd(), $fileName)),
+                    Path::makeAbsolute('**/' . $pattern, getcwd())
+                ) ? array_merge($carry, $rules) : $carry
             );
         }, []);
     }


### PR DESCRIPTION
# Context

```ini
# C:\Users\Ghislain\Desktop\myproject\.editorconfig
root = true

[*]
indent_style = space
indent_size = 4
```

```php
<?php
// C:\Users\Ghislain\Desktop\myproject\bad.php

function badFunction()
{
  echo "This line is indented with 2 spaces.\n";
}
```

```shell-script
php\php.exe -v

PHP 7.2.0 (cli) (built: Nov 28 2017 23:48:49) ( ZTS MSVC15 (Visual C++ 2017) x64 )
Copyright (c) 1997-2017 The PHP Group
Zend Engine v3.2.0, Copyright (c) 1998-2017 Zend Technologies
```

```shell-script
php\php.exe editorconfig-checker.php\src\EditorconfigChecker.php -l myproject\*

myproject\.editorconfig
myproject\bad.php
total: 2 files
Successfully checked 9 lines in 2 files :)
```

# Debug

[src/EditorconfigChecker/Editorconfig/Editorconfig.php#L34](https://github.com/editorconfig-checker/editorconfig-checker.php/blob/1bed41dd318b3244027616a5d114afa2aa774b62/src/EditorconfigChecker/Editorconfig/Editorconfig.php#L34)

```
array(2) {
  ["sprintf('%s/%s', getcwd(), $fileName)"]=>
  string(33) "C:\Users\Ghislain\Desktop/bad.php"
  ["Path::makeAbsolute('**/' . $pattern, getcwd())"]=>
  string(30) "C:/Users/Ghislain/Desktop/**/*"
}
```

`Glob::match($path, $glob)` always returns `false` under Windows because `$path` uses both `\` and '/' as directory separators.