### PR TITLE
Update symfony/finder dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,12 @@
     },
     "config": {
         "platform": {
-            "php": "7"
+            "php": "7.1.3"
         }
     },
     "require": {
         "webmozart/glob": "^4.1",
-        "symfony/finder": "^3.3",
+        "symfony/finder": "^3.3 | ^4.0",
         "php": "7.*"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -1,32 +1,32 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "090c2bfcb031db8123c34024a97c085d",
+    "content-hash": "39c02e7d6ce30ed5a5cb6d5ea1f38f72",
     "packages": [
         {
             "name": "symfony/finder",
-            "version": "v3.3.6",
+            "version": "v4.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "baea7f66d30854ad32988c11a09d7ffd485810c4"
+                "reference": "e162f1df3102d0b7472805a5a9d5db9fcf0a8068"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/baea7f66d30854ad32988c11a09d7ffd485810c4",
-                "reference": "baea7f66d30854ad32988c11a09d7ffd485810c4",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/e162f1df3102d0b7472805a5a9d5db9fcf0a8068",
+                "reference": "e162f1df3102d0b7472805a5a9d5db9fcf0a8068",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9"
+                "php": "^7.1.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.3-dev"
+                    "dev-master": "4.1-dev"
                 }
             },
             "autoload": {
@@ -53,7 +53,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2017-06-01T21:01:25+00:00"
+            "time": "2018-07-26T11:24:31+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -206,12 +206,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/codeclimate/php-test-reporter.git",
-                "reference": "22b07b85a996d2e173fac6838033a0e0cc2b465d"
+                "reference": "f35752238d994c8894a3c079bdbe2c535e0265af"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/codeclimate/php-test-reporter/zipball/22b07b85a996d2e173fac6838033a0e0cc2b465d",
-                "reference": "22b07b85a996d2e173fac6838033a0e0cc2b465d",
+                "url": "https://api.github.com/repos/codeclimate/php-test-reporter/zipball/f35752238d994c8894a3c079bdbe2c535e0265af",
+                "reference": "f35752238d994c8894a3c079bdbe2c535e0265af",
                 "shasum": ""
             },
             "require": {
@@ -257,7 +257,7 @@
                 "codeclimate",
                 "coverage"
             ],
-            "time": "2017-12-03T20:50:46+00:00"
+            "time": "2018-04-11T15:45:47+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -1378,6 +1378,7 @@
                 "github",
                 "test"
             ],
+            "abandoned": "php-coveralls/php-coveralls",
             "time": "2017-12-06T23:17:56+00:00"
         },
         {
@@ -2502,6 +2503,6 @@
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7"
+        "php": "7.1.3"
     }
 }


### PR DESCRIPTION
Hi there !

Thanks for the good work on this package, it comes quite handy in our workflow and save us time. We noticed the outdated `symfony/finder` component, as composer yelled at us, and well, there's very little BC break from v3.3.6 to v4.1.3 (only `Symfony\Component\Finder\Iterator\FilterIterator` removal, which editorconfig-checker doesn't rely upon AFAIK). You can double check just to be safe : https://github.com/symfony/finder/compare/v3.3.6...v4.1.3
