### PR TITLE
Ignore phpstan error message

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,3 +9,9 @@ parameters:
     checkMissingCallableSignature: true
     checkUninitializedProperties: true
     checkTooWideReturnTypesInProtectedAndPublicMethods: true
+
+    ignoreErrors:
+        -
+            # CORE_VERSION constant may change in the future
+            message: '~Right side of && is always true~'
+            path: 'src/EditorconfigChecker/Utilities.php'


### PR DESCRIPTION
fixing issue from previous PR (https://github.com/editorconfig-checker/editorconfig-checker.php/pull/220)

i do not like muting errors, but i could not think about better way to deal with this. hardcoding one branch instead of an `if` might lead to broken url in future, when the core lib version is changed