### PR TITLE
Use core v3.0.0

### DIFF
--- a/src/EditorconfigChecker/Cli.php
+++ b/src/EditorconfigChecker/Cli.php
@@ -4,7 +4,7 @@ namespace EditorconfigChecker;
 
 use EditorconfigChecker\Utilities;
 
-define('CORE_VERSION', '2.8.0');
+define('CORE_VERSION', '3.0.0');
 
 class Cli
 {

--- a/src/EditorconfigChecker/Utilities.php
+++ b/src/EditorconfigChecker/Utilities.php
@@ -83,7 +83,7 @@ class Utilities
             $releaseSuffix = '.exe.tar.gz';
         }
         $releaseUrl = sprintf(
-            'https://github.com/editorconfig-checker/editorconfig-checker/releases/download/%s/%s',
+            'https://github.com/editorconfig-checker/editorconfig-checker/releases/download/v%s/%s',
             $version,
             $releaseName . $releaseSuffix
         );


### PR DESCRIPTION
- Contains a fix for `Could not get the ContentType` errors 
  - See https://github.com/editorconfig-checker/editorconfig-checker/issues/326
- Core release: https://github.com/editorconfig-checker/editorconfig-checker/releases/tag/v3.0.0