### PR TITLE
chore!: rename `ec` to `editorconfig-checker`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 /vendor/
 /Build/bin/
-/bin/ec-*
+/bin/editorconfig-checker-*

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,2 @@
 docker-run:
-	docker run -it --rm --volume=$$PWD:/usr/src/myapp -u $$(id -u):$$(id -g) --name ec ec /bin/bash
+	docker run -it --rm --volume=$$PWD:/usr/src/myapp -u $$(id -u):$$(id -g) --name editorconfig-checker editorconfig-checker /bin/bash

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This is a tool to check if your files consider your .editorconfig. Most tools - 
 
 ## Important
 
-This is only a wrapper for the core [editorconfig-checker](https://github.com/editorconfig-checker/editorconfig-checker). 
+This is only a wrapper for the core [editorconfig-checker](https://github.com/editorconfig-checker/editorconfig-checker).
 You should have a look at this repository to know how this tool can be used and what possibilities/caveats are there.
 This version can be used in the same way as the core as every argument is simply passed down to it.
 
@@ -40,7 +40,7 @@ composer require --dev editorconfig-checker/editorconfig-checker
 ## Usage
 
 ```
-vendor/bin/ec
+vendor/bin/editorconfig-checker
 ```
 
 ## Configuration
@@ -49,14 +49,8 @@ You can configure analysis in `.ecrc` json file, e.g.:
 
 ```json
 {
-    "Exclude": [
-        "^vendor\/",
-        "^var\/",
-        "^\\.idea\/",
-        "\\.phar$"
-    ]
+  "Exclude": ["^vendor/", "^var/", "^\\.idea/", "\\.phar$"]
 }
-
 ```
 
 Full list of config options is in [core docs](https://github.com/editorconfig-checker/editorconfig-checker?tab=readme-ov-file#configuration)
@@ -65,10 +59,9 @@ Full list of config options is in [core docs](https://github.com/editorconfig-ch
 
 Please head to [core docs](https://github.com/editorconfig-checker/editorconfig-checker?tab=readme-ov-file#usage).
 
-
 ## Support
 
-If you have any questions or just want to chat join #editorconfig-checker on 
+If you have any questions or just want to chat join #editorconfig-checker on
 freenode(IRC).
-If you don't have an IRC-client set up you can use the 
+If you don't have an IRC-client set up you can use the
 [freenode webchat](https://webchat.freenode.net/?channels=editorconfig-checker).

--- a/bin/editorconfig-checker
+++ b/bin/editorconfig-checker
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-./$(dirname $0)/ec "$@"
+./$(dirname $0)/editorconfig-checker "$@"

--- a/composer.json
+++ b/composer.json
@@ -34,14 +34,13 @@
             "@lint:self"
         ],
         "lint:psr2": "phpcs --standard=PSR2 src/**",
-        "lint:self": "./bin/ec",
+        "lint:self": "./bin/editorconfig-checker",
         "test": "phpunit tests/ --bootstrap vendor/autoload.php --colors=always",
         "test:coverage": "phpunit -c ./phpunit.xml.dist",
         "check": "phpstan analyse -vvv"
     },
     "bin": [
-        "bin/editorconfig-checker",
-        "bin/ec"
+        "bin/editorconfig-checker"
     ],
     "autoload": {
         "psr-4": {

--- a/src/EditorconfigChecker/Utilities.php
+++ b/src/EditorconfigChecker/Utilities.php
@@ -44,7 +44,7 @@ class Utilities
      */
     public static function getReleaseName(): string
     {
-        return sprintf('ec-%s-%s', Utilities::getCurrentOs(), Utilities::getCurrentArch());
+        return sprintf('editorconfig-checker-%s-%s', Utilities::getCurrentOs(), Utilities::getCurrentArch());
     }
 
     /**

--- a/tests/Cli/CliTest.php
+++ b/tests/Cli/CliTest.php
@@ -15,7 +15,7 @@ final class CliTest extends TestCase
         $this->assertEquals(Cli::run([$this->basePath()]), 0);
 
         // TestFiles should fail
-        system("cd ./Build && ../bin/ec", $return);
+        system("cd ./Build && ../bin/editorconfig-checker", $return);
         $this->assertEquals($return, 1);
     }
 


### PR DESCRIPTION
BREAKING CHANGE: `ec` alias no longer available.

Ref: https://github.com/editorconfig-checker/editorconfig-checker/pull/371